### PR TITLE
Tests: Create svcconn with autocommit on

### DIFF
--- a/tests/fix_db.py
+++ b/tests/fix_db.py
@@ -62,6 +62,6 @@ def svcconn(dsn):
     """
     from psycopg3 import Connection
 
-    conn = Connection.connect(dsn)
+    conn = Connection.connect(dsn, autocommit=True)
     yield conn
     conn.close()

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -123,14 +123,12 @@ def _execmany(svcconn):
         create table execmany (id serial primary key, num integer, data text)
         """
     )
-    svcconn.commit()
 
 
 @pytest.fixture(scope="function")
 def execmany(svcconn, _execmany):
     cur = svcconn.cursor()
     cur.execute("truncate table execmany")
-    svcconn.commit()
 
 
 def test_executemany(conn, execmany):

--- a/tests/test_cursor_async.py
+++ b/tests/test_cursor_async.py
@@ -126,14 +126,12 @@ async def _execmany(svcconn):
         create table execmany (id serial primary key, num integer, data text)
         """
     )
-    svcconn.commit()
 
 
 @pytest.fixture(scope="function")
 async def execmany(svcconn, _execmany):
     cur = svcconn.cursor()
     cur.execute("truncate table execmany")
-    svcconn.commit()
 
 
 async def test_executemany(aconn, execmany):

--- a/tests/types/test_composite.py
+++ b/tests/types/test_composite.py
@@ -99,7 +99,6 @@ def testcomp(svcconn):
         create type testcomp as (foo text, bar int8, baz float8);
         """
     )
-    svcconn.commit()
 
 
 def test_fetch_info(conn, testcomp):


### PR DESCRIPTION
So that you don't deadlock the test run if you forget to call commit()