### PR TITLE
Don't be so eager to execute 'begin'

### DIFF
--- a/psycopg3/psycopg3/connection.py
+++ b/psycopg3/psycopg3/connection.py
@@ -241,7 +241,7 @@ class Connection(BaseConnection):
         if self._autocommit:
             return
 
-        if self.pgconn.transaction_status == TransactionStatus.INTRANS:
+        if self.pgconn.transaction_status != TransactionStatus.IDLE:
             return
 
         self.pgconn.send_query(b"begin")
@@ -349,7 +349,7 @@ class AsyncConnection(BaseConnection):
         if self._autocommit:
             return
 
-        if self.pgconn.transaction_status == TransactionStatus.INTRANS:
+        if self.pgconn.transaction_status != TransactionStatus.IDLE:
             return
 
         self.pgconn.send_query(b"begin")

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -107,6 +107,9 @@ def test_auto_transaction_fail(conn):
         cur.execute("meh")
     assert conn.pgconn.transaction_status == conn.TransactionStatus.INERROR
 
+    with pytest.raises(psycopg3.errors.InFailedSqlTransaction):
+        cur.execute("select 1")
+
     conn.commit()
     assert conn.pgconn.transaction_status == conn.TransactionStatus.IDLE
     assert cur.execute("select * from foo").fetchone() is None


### PR DESCRIPTION
Only execute an automatic 'begin' statement if the TransactionStatus is
IDLE, so that a failure to execute 'begin' doesn't overshadow a failure
to execute a user query.