### PR TITLE
Adapt find_library() call to find libpq.dll on Windows

### DIFF
--- a/psycopg3/psycopg3/pq/__init__.py
+++ b/psycopg3/psycopg3/pq/__init__.py
@@ -37,7 +37,7 @@ PGcancel: Type[proto.PGcancel]
 
 def import_from_libpq() -> None:
     """
-    Import pq objects implementation from the best libpw wrapper available.
+    Import pq objects implementation from the best libpq wrapper available.
 
     If an implementation is requested try to import only it, otherwise
     try to import the best implementation available.

--- a/psycopg3/psycopg3/pq/_pq_ctypes.py
+++ b/psycopg3/psycopg3/pq/_pq_ctypes.py
@@ -6,13 +6,17 @@ libpq access using ctypes
 
 import ctypes
 import ctypes.util
+import sys
 from ctypes import Structure, CFUNCTYPE, POINTER
 from ctypes import c_char, c_char_p, c_int, c_size_t, c_ubyte, c_uint, c_void_p
 from typing import List, Tuple
 
 from psycopg3.errors import NotSupportedError
 
-libname = ctypes.util.find_library("pq")
+if sys.platform == "win32":
+    libname = ctypes.util.find_library("libpq.dll")
+else:
+    libname = ctypes.util.find_library("pq")
 if not libname:
     raise ImportError("libpq library not found")
 

--- a/tests/fix_pq.py
+++ b/tests/fix_pq.py
@@ -1,5 +1,7 @@
 import re
 import operator
+import sys
+
 import pytest
 
 
@@ -38,7 +40,10 @@ def libpq():
 
     try:
         # Not available when testing the binary package
-        libname = ctypes.util.find_library("pq")
+        if sys.platform == "win32":
+            libname = ctypes.util.find_library("libpq.dll")
+        else:
+            libname = ctypes.util.find_library("pq")
         assert libname, "libpq libname not found"
         return ctypes.pydll.LoadLibrary(libname)
     except Exception as e:


### PR DESCRIPTION
Open to suggestions on:

1. How to 'detect' Windows: There are a number of options: `os.name`, `sys.platform`, `os.uname()`, and I have no strong opinion on which is best to use.
2. How to de-duplicate this code (if deemed necessary, since there are only two occurrences, one of which is in test code): I looked around for places where to put a helper method (and fixed a typo in `pq.__init__` while I was at it) but wasn't sure where it would best fit.