### PR TITLE
Tests for consequences of using @contextmanager

### DIFF
--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -90,6 +90,25 @@ def test_basic(conn):
     assert not in_transaction(conn)
 
 
+def test_not_reusable(conn):
+    tx = conn.transaction()
+    tx.__enter__()
+    tx.__exit__(None, None, None)
+    with pytest.raises(AttributeError):
+        tx.__enter__()
+
+
+def test_as_decorator(conn):
+    assert not in_transaction(conn)
+
+    @conn.transaction(savepoint_name="foo")
+    def f():
+        assert in_transaction(conn)
+
+    f()
+    assert not in_transaction(conn)
+
+
 def test_exposes_associated_connection(conn):
     """Transaction exposes its connection as a read-only property."""
     with conn.transaction() as tx:


### PR DESCRIPTION
Was playing around trying to grok the use of `@[async]contextmanager` on `[Async]Connection.transaction()` and found a couple of curious consequences that I've captured with these two tests:

1. `@contextmanager` makes `transaction()` usable as a decorator. Is this good? Do we want to document/test this explicitly? Or remove this feature?
2. `@contextmanager` makes the context object not re-usable already, so if you try to reuse it, you get an intractable `AttributeError` from the internals of `@contextmanager` before hitting your yolo assert (so the other question of whether to assert or raise `ProgrammingError` is moot -- it _should_ be an assert because it is _not_ actually reachable by user code!):
```
self = <contextlib._GeneratorContextManager object at 0x000001FB6F869970>
    def __enter__(self):
        # do not keep args and kwds alive unnecessarily
        # they are only needed for recreation, which is not possible anymore
>       del self.args, self.kwds, self.func
E       AttributeError: args
```

I still don't fully understand the `@contexmanager` wrapper on what is already a context manager -- is this purely intended to "internalise" the `__init__` and `__enter__` of the `Transaction` object? Or is it something else?

(If only this, then what's the actual benefit of this, now that there is no volatile state involved in `Transaction.__init__`?)