### PR TITLE
Windows compatibility for tests

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -94,7 +94,7 @@ t.join()
     with (tmpdir / "mptest.py").open("w") as f:
         f.write(module)
     env = dict(os.environ)
-    env["PYTHONPATH"] = tmpdir + os.pathsep + env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = str(tmpdir + os.pathsep + env.get("PYTHONPATH", ""))
     # TODO: debug this. Importing c module fails on travis in this scenario
     env.pop("PSYCOPG3_IMPL", None)
     out = sp.check_output(

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,5 @@
 import gc
+import sys
 import time
 import socket
 import pytest
@@ -35,9 +36,10 @@ def test_connect_bad():
 
 @pytest.mark.slow
 @pytest.mark.xfail
+@pytest.mark.skipif(sys.platform == "win32", reason="connect() hangs on Win32")
 def test_connect_timeout():
     s = socket.socket(socket.AF_INET)
-    s.bind(("", 0))
+    s.bind(("localhost", 0))
     port = s.getsockname()[1]
     s.listen(0)
 


### PR DESCRIPTION
* Skip test_connect_timeout() on Windows for the time being as
  Connection.connect() hangs for some reason. This skip can probably
  go away once connection timeouts are implemented.
* test_multiprocess_close(): Turn LocalPath instance back into a str
  before putting it back into env["PYTHONPATH"] to avoid failure in:
  _winapi.CreateProcess(): TypeError: environment can only contain str