### PR TITLE
Alias Task to asyncio.Future for python version < 3.8

### DIFF
--- a/psycopg3/psycopg3/pool/async_pool.py
+++ b/psycopg3/psycopg3/pool/async_pool.py
@@ -18,7 +18,7 @@ from collections import deque
 from .. import errors as e
 from ..pq import TransactionStatus
 from ..connection import AsyncConnection
-from ..utils.compat import asynccontextmanager, create_task
+from ..utils.compat import Task, asynccontextmanager, create_task
 
 from .base import ConnectionAttempt, BasePool
 from .sched import AsyncScheduler
@@ -57,7 +57,7 @@ class AsyncConnectionPool(BasePool[AsyncConnection]):
 
         self._sched = AsyncScheduler()
         self._tasks: "asyncio.Queue[MaintenanceTask]" = asyncio.Queue()
-        self._workers: "List[asyncio.Task[None]]" = []
+        self._workers: List[Task[None]] = []
 
         super().__init__(conninfo, **kwargs)
 

--- a/psycopg3/psycopg3/utils/compat.py
+++ b/psycopg3/psycopg3/utils/compat.py
@@ -24,6 +24,7 @@ else:
 
 if sys.version_info >= (3, 8):
     create_task = asyncio.create_task
+    Task = asyncio.Task
 
 elif sys.version_info >= (3, 7):
 
@@ -32,6 +33,7 @@ elif sys.version_info >= (3, 7):
     ) -> "asyncio.Future[T]":
         return asyncio.create_task(coro)
 
+    Task = asyncio.Future
 
 else:
 
@@ -40,5 +42,6 @@ else:
     ) -> "asyncio.Future[T]":
         return asyncio.ensure_future(coro)
 
+    Task = asyncio.Future
 
 __all__ = ["asynccontextmanager", "get_running_loop", "create_task"]


### PR DESCRIPTION
This resolves the following mypy error on Python 3.7:

    psycopg3/psycopg3/pool/async_pool.py:72: error: Argument 1 to "append" of "list" has incompatible type "Future[None]"; expected "Task[None]" [arg-type]