### PR TITLE
Check documentation build in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,3 +19,5 @@ jobs:
         run: tox -e flake8
       - name: Run mypy
         run: tox -e mypy
+      - name: Check documentation
+        run: tox -e docs


### PR DESCRIPTION
This is useful to prevent regressions during pull requests as the docs build uses `-W` flag of sphinx.