### PR TITLE
Upgrade testing libraries

### DIFF
--- a/psycopg3/setup.py
+++ b/psycopg3/setup.py
@@ -35,9 +35,9 @@ extras_require = {
         "mypy >= 0.812",
         "pproxy >= 2.7, < 2.8",
         "pytest >= 6.2.4, < 6.3",
-        "pytest-asyncio >= 0.14.0, < 0.15",
-        "pytest-randomly >= 3.5, < 3.6",
-        "tenacity >= 6.3, < 6.4",
+        "pytest-asyncio >= 0.15.0, < 0.16",
+        "pytest-randomly >= 3.7, < 3.8",
+        "tenacity >= 7, < 7.1",
     ],
     "dev": [
         "black",

--- a/psycopg3/setup.py
+++ b/psycopg3/setup.py
@@ -34,7 +34,7 @@ extras_require = {
     "test": [
         "mypy >= 0.812",
         "pproxy >= 2.7, < 2.8",
-        "pytest >= 6, < 6.1",
+        "pytest >= 6.2.4, < 6.3",
         "pytest-asyncio >= 0.14.0, < 0.15",
         "pytest-randomly >= 3.5, < 3.6",
         "tenacity >= 6.3, < 6.4",


### PR DESCRIPTION
I was trying to run with python 3.10, so needed pytest 6.2.4. (There another issue after that.)
It seems that nothing breaks with more recent versions of all of these.