### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,8 +95,6 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: print username
-        run: whoami
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
@@ -126,7 +124,7 @@ jobs:
     env:
       PSYCOPG3_IMPL: python
       PGHOST: 127.0.0.1
-      PGUSER: postgres
+      PGUSER: runner 
       PSYCOPG3_TEST_DSN: "dbname=postgres"
 
     steps:
@@ -163,7 +161,7 @@ jobs:
     env:
       PSYCOPG3_IMPL: c
       PGHOST: 127.0.0.1
-      PGUSER: postgres
+      PGUSER: runner 
       PSYCOPG3_TEST_DSN: "dbname=postgres"
       # skip tests failing on importing psycopg3_c.pq on subprocess
       # they only fail on Travis, work ok locally under tox too.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,6 +95,8 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: print username
+        run: whoami
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  python:
-    name: Python implementation
+  test-linux:
+    name: Python implementation for Linux
     runs-on: ubuntu-20.04
 
     strategy:
@@ -53,8 +53,8 @@ jobs:
       - name: Run tests
         run: tox -c psycopg3 -e ${{ matrix.python }} -- --color yes
 
-  c:
-    name: C implementation
+  test-c-linux:
+    name: C implementation for Linux
     runs-on: ubuntu-20.04
 
     strategy:
@@ -103,3 +103,80 @@ jobs:
         run: pip install tox
       - name: Run tests
         run: tox -c psycopg3_c -e ${{ matrix.python }} -- --color yes
+
+  test-macos-latest:
+    name: Python implementation for macOS
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python: 3.6
+            postgres: 10
+          - python: 3.7
+            postgres: 11
+          - python: 3.8
+            postgres: 12
+          - python: 3.9
+            postgres: 13
+
+    env:
+      PSYCOPG3_IMPL: python
+      PGHOST: 127.0.0.1
+      PGUSER: postgres
+      PSYCOPG3_TEST_DSN: "dbname=postgres"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install postgres
+        run: brew install postgresql@${{ matrix.postgres }}
+      - name: Start postgres
+        run: brew services start postgresql
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests
+        run: tox -c psycopg3 -e ${{ matrix.python }} -- --color yes
+
+  test-c-macos-latest:
+    name: C implementation for macOS
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python: 3.6
+            postgres: 13
+          - python: 3.7
+            postgres: 12
+          - python: 3.8
+            postgres: 11
+          - python: 3.9
+            postgres: 10
+
+    env:
+      PSYCOPG3_IMPL: c
+      PGHOST: 127.0.0.1
+      PGUSER: postgres
+      PSYCOPG3_TEST_DSN: "dbname=postgres"
+      # skip tests failing on importing psycopg3_c.pq on subprocess
+      # they only fail on Travis, work ok locally under tox too.
+      PYTEST_ADDOPTS: "-m 'not subprocess'"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install postgres
+        run: brew install postgresql@${{ matrix.postgres }}
+      - name: Start postgres
+        run: brew services start postgresql
+      - name: Install tox
+        run: pip install tox
+      - name: Run tests
+        run: tox -c psycopg3 -e ${{ matrix.python }} -- --color yes

--- a/psycopg3/psycopg3/pq/_pq_ctypes.py
+++ b/psycopg3/psycopg3/pq/_pq_ctypes.py
@@ -15,6 +15,8 @@ from psycopg3.errors import NotSupportedError
 
 if sys.platform == "win32":
     libname = ctypes.util.find_library("libpq.dll")
+elif sys.platform == "darwin":
+    libname = ctypes.util.find_library("libpq.dylib")
 else:
     libname = ctypes.util.find_library("pq")
 if not libname:

--- a/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
+++ b/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
@@ -24,7 +24,7 @@ IF UNAME_SYSNAME == "Darwin":
     cdef inline uint16_t htole16(uint16_t host_16bits):
         return OSSwapHostToLittleInt16(host_16bits)
     cdef inline uint16_t be16toh(uint16_t big_endian_16bits):
-        return OSSwapHostToLittleInt16(big_endian_16bits)
+        return OSSwapBigToHostInt16(big_endian_16bits)
     cdef inline uint16_t le16toh(uint16_t little_endian_16bits):
         return OSSwapLittleToHostInt16(little_endian_16bits)
 

--- a/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
+++ b/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
@@ -4,20 +4,22 @@
 from libc.stdint cimport uint16_t, uint32_t, uint64_t
 
 IF UNAME_SYSNAME == "Darwin":
-    from libkern.OSByteOrder import (
-        OSSwapHostToBigInt16,
-        OSSwapHostToLittleInt16,
-        OSSwapBigToHostInt16,
-        OSSwapLittleToHostInt16,
-        OSSwapHostToBigInt32,
-        OSSwapHostToLittleInt32,
-        OSSwapBigToHostInt32,
-        OSSwapLittleToHostInt32,
-        OSSwapHostToBigInt64,
-        OSSwapHostToLittleInt64,
-        OSSwapBigToHostInt64,
-        OSSwapLittleToHostInt64
-    )
+
+    cdef extern from "<libkern/OSByteOrder.h>" nogil:
+        cdef uint16_t OSSwapHostToBigInt16(uint16_t x) 
+        cdef uint16_t OSSwapHostToLittleInt16(uint16_t x)
+        cdef uint16_t OSSwapBigToHostInt16(uint16_t x)
+        cdef uint16_t OSSwapLittleToHostInt16(uint16_t x)
+
+        cdef uint32_t OSSwapHostToBigInt32(uint32_t x)
+        cdef uint32_t OSSwapHostToLittleInt32(uint32_t x)
+        cdef uint32_t OSSwapBigToHostInt32(uint32_t x)
+        cdef uint32_t OSSwapLittleToHostInt32(uint32_t x)
+
+        cdef uint64_t OSSwapHostToBigInt64(uint64_t x)
+        cdef uint64_t OSSwapHostToLittleInt64(uint64_t x)
+        cdef uint64_t OSSwapBigToHostInt64(uint64_t x)
+        cdef uint64_t OSSwapLittleToHostInt64(uint64_t x)
 
     cdef inline uint16_t htobe16(uint16_t host_16bits):
         return OSSwapHostToBigInt16(host_16bits)

--- a/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
+++ b/psycopg3_c/psycopg3_c/_psycopg3/endian.pxd
@@ -3,20 +3,62 @@
 
 from libc.stdint cimport uint16_t, uint32_t, uint64_t
 
+IF UNAME_SYSNAME == "Darwin":
+    from libkern.OSByteOrder import (
+        OSSwapHostToBigInt16,
+        OSSwapHostToLittleInt16,
+        OSSwapBigToHostInt16,
+        OSSwapLittleToHostInt16,
+        OSSwapHostToBigInt32,
+        OSSwapHostToLittleInt32,
+        OSSwapBigToHostInt32,
+        OSSwapLittleToHostInt32,
+        OSSwapHostToBigInt64,
+        OSSwapHostToLittleInt64,
+        OSSwapBigToHostInt64,
+        OSSwapLittleToHostInt64
+    )
 
-cdef extern from "<endian.h>" nogil:
+    cdef inline uint16_t htobe16(uint16_t host_16bits):
+        return OSSwapHostToBigInt16(host_16bits)
+    cdef inline uint16_t htole16(uint16_t host_16bits):
+        return OSSwapHostToLittleInt16(host_16bits)
+    cdef inline uint16_t be16toh(uint16_t big_endian_16bits):
+        return OSSwapHostToLittleInt16(big_endian_16bits)
+    cdef inline uint16_t le16toh(uint16_t little_endian_16bits):
+        return OSSwapLittleToHostInt16(little_endian_16bits)
 
-    cdef uint16_t htobe16(uint16_t host_16bits)
-    cdef uint16_t htole16(uint16_t host_16bits)
-    cdef uint16_t be16toh(uint16_t big_endian_16bits)
-    cdef uint16_t le16toh(uint16_t little_endian_16bits)
+    cdef inline uint32_t htobe32(uint32_t host_32bits):
+        return OSSwapHostToBigInt32(host_32bits)
+    cdef inline uint32_t htole32(uint32_t host_32bits):
+        return OSSwapHostToLittleInt32(host_32bits)
+    cdef inline uint32_t be32toh(uint32_t big_endian_32bits):
+        return OSSwapBigToHostInt32(big_endian_32bits)
+    cdef inline uint32_t le32toh(uint32_t little_endian_32bits):
+        return OSSwapLittleToHostInt32(little_endian_32bits)
 
-    cdef uint32_t htobe32(uint32_t host_32bits)
-    cdef uint32_t htole32(uint32_t host_32bits)
-    cdef uint32_t be32toh(uint32_t big_endian_32bits)
-    cdef uint32_t le32toh(uint32_t little_endian_32bits)
-
-    cdef uint64_t htobe64(uint64_t host_64bits)
-    cdef uint64_t htole64(uint64_t host_64bits)
-    cdef uint64_t be64toh(uint64_t big_endian_64bits)
-    cdef uint64_t le64toh(uint64_t little_endian_64bits)
+    cdef inline uint64_t htobe64(uint64_t host_64bits):
+        return OSSwapHostToBigInt64(host_64bits)
+    cdef inline uint64_t htole64(uint64_t host_64bits):
+        return OSSwapHostToLittleInt64(host_64bits)
+    cdef inline uint64_t be64toh(uint64_t big_endian_64bits):
+        return OSSwapBigToHostInt64(big_endian_64bits)
+    cdef inline uint64_t le64toh(uint64_t little_endian_64bits):
+        return OSSwapLittleToHostInt64(little_endian_64bits)
+ELSE:
+    cdef extern from "<endian.h>" nogil:
+    
+        cdef uint16_t htobe16(uint16_t host_16bits)
+        cdef uint16_t htole16(uint16_t host_16bits)
+        cdef uint16_t be16toh(uint16_t big_endian_16bits)
+        cdef uint16_t le16toh(uint16_t little_endian_16bits)
+    
+        cdef uint32_t htobe32(uint32_t host_32bits)
+        cdef uint32_t htole32(uint32_t host_32bits)
+        cdef uint32_t be32toh(uint32_t big_endian_32bits)
+        cdef uint32_t le32toh(uint32_t little_endian_32bits)
+    
+        cdef uint64_t htobe64(uint64_t host_64bits)
+        cdef uint64_t htole64(uint64_t host_64bits)
+        cdef uint64_t be64toh(uint64_t big_endian_64bits)
+        cdef uint64_t le64toh(uint64_t little_endian_64bits)


### PR DESCRIPTION
This pull request has the two changes I had to make to get psycopg3 running on macOS.

1. First, `<endian.h>` is `<machine/endian.h>` on macOS, but sadly, even with this change, the crippled Mac version lacks `htobe16` functions etc. The workaround is using some functions from `libkern` to define these functions.
2. Second, `ctypes.util.find_library` needs to search with a `.dylib` extension.

Hope this is useful and thank you for this great library!